### PR TITLE
Fix Linux build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Build
 1. Clone the repo
     - `git clone https://github.com/MateriiApps/Gloom.git && cd Gloom`
 2. Build the project
-    - Linux: `chmod +x ./gradlew && gradlew assembleDebug`
+    - Linux: `chmod +x gradlew && ./gradlew assembleDebug`
     - Windows: `./gradlew assembleDebug`
 3. Install on device
     - [Enable usb debugging](https://developer.android.com/studio/debug/dev-options) and plug in your phone


### PR DESCRIPTION
```
rickastlee@debian:~/Gloom$ gradlew assembleDebug
bash: gradlew: command not found
```

```
rickastlee@debian:~/Gloom$ ./gradlew assembleDebug
Starting a Gradle Daemon (subsequent builds will be faster)
Errors during XML parse:
Additionally, the fallback loader failed to parse the XML.
Checking the license for package Android SDK Platform 35 in /home/rickastlee/Android/Sdk/licenses
License for package Android SDK Platform 35 accepted.
Preparing "Install Android SDK Platform 35 (revision 2)".
"Install Android SDK Platform 35 (revision 2)" ready.
Installing Android SDK Platform 35 in /home/rickastlee/Android/Sdk/platforms/android-35
"Install Android SDK Platform 35 (revision 2)" complete.
"Install Android SDK Platform 35 (revision 2)" finished.
<===----------> 27% EXECUTING [2m]

> Task :app:android:stripDebugDebugSymbols
Unable to strip the following libraries, packaging them as they are: libandroidx.graphics.path.so.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.9/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 6m 37s
147 actionable tasks: 142 executed, 5 up-to-date
```
